### PR TITLE
Updated readme on middleware setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In `app/Http/Kernel.php`
 ```php
     protected $routeMiddleware = [
             /// Other Middleware
-            'xml' => XmlRequestMiddleware::class,
+            'xml' => \XmlMiddleware\XmlRequestMiddleware::class,
         ];
 ```
 


### PR DESCRIPTION
included fully qualified name for request middleware in
app/Http/Kernel.php to get it working in laravel 5.5