### PR TITLE
Empty request no longer trigger fatal error.

### DIFF
--- a/src/XmlRequestMiddleware.php
+++ b/src/XmlRequestMiddleware.php
@@ -4,19 +4,26 @@ namespace XmlMiddleware;
 
 use Closure;
 
+/**
+ * Class XmlRequestMiddleware
+ * @package XmlMiddleware
+ */
 class XmlRequestMiddleware
 {
     /**
      * Handle an incoming request.
      *
      * @param  \Illuminate\Http\Request $request
-     * @param  \Closure $next
+     * @param  \Closure                 $next
+     *
      * @return mixed
      */
     public function handle($request, Closure $next)
     {
-        $request->merge($request->xml());
-        
+        // We pass an array to merge if the xml parsing somewhat failed, no error will trigger
+        // If the xml request contains an empty body
+        $request->merge($request->xml() ?: []);
+
         return $next($request);
     }
 }


### PR DESCRIPTION
The middleware trigger a fatal error if the request body is empty, i came accros the problem so i came to share the resolution.